### PR TITLE
docs: feature Glass screenshot in hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Codex Skin for Hermes Desktop
 
+![Codex Skin using a native Hermes theme with the Glass background](screenshots/codex-skin-native-glass.png)
+
 Codex Skin gives Hermes Desktop a Codex-inspired chat layout while preserving Hermes' native behavior. It supports native Hermes themes and the native Glass background, while the original Codex colors remain available through the **Codex Skin** theme in Appearance settings.
 
 > [!IMPORTANT]
@@ -43,10 +45,6 @@ Open the command palette and run **Codex Skin: Composer width**. The row shows t
 The `+` menu above the composer follows the rendered composer width in both modes.
 
 ## Screenshots
-
-### Native Hermes themes and Glass
-
-![Codex Skin using a native Hermes theme with the Glass background](screenshots/codex-skin-native-glass.png)
 
 ### Codex Skin theme
 


### PR DESCRIPTION
![Codex Skin using a native Hermes theme with the Glass background](https://raw.githubusercontent.com/FPSUnleashed/hermes-codex-skin/main/screenshots/codex-skin-native-glass.png)

## Summary

- Moves the native Hermes theme + Glass screenshot directly below the README title.
- Removes the duplicated copy from the lower Screenshots section.
- Changes documentation only. Plugin and release asset bytes remain untouched.

## Verification

- [x] Hero image resolves from the public `dev` branch
- [x] README contains exactly one reference to the Glass screenshot
- [x] `git diff --check` passes
