### PR TITLE
release: Codex Skin v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented here.
 
+## [1.3.0] - 2026-08-29
+
+### Added
+
+- Optional **Pinned user messages** command-palette setting with persisted `Hermes` and `Off` modes. Native Hermes pinning remains the default.
+
+### Verification
+
+- 64 automated checks pass.
+- The exact toggle was validated in the live Hermes Desktop renderer: `Hermes` keeps `position: sticky`, `Off` applies `position: static`, and switching back restores native pinning.
+
 ## [1.2.0] - 2026-08-27
 
 ### Added

--- a/CHECKSUMS.sha256
+++ b/CHECKSUMS.sha256
@@ -1,1 +1,1 @@
-b3bad99f0b886cd27f79d368fc1b97064cfc70ec96c0d7dfc38d91959f9565ce  codex-chat-look/plugin.js
+035a10170eb341569048672b3c7d10331d5ac36cd884c16ec251694471342fc3  codex-chat-look/plugin.js

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Codex Skin gives Hermes Desktop a Codex-inspired chat layout while preserving He
 
 ## Status
 
-**Stable.** Version 1.2.0 has been exercised in Hermes Desktop and is covered by an automated regression suite. It uses Hermes' supported desktop plugin entry point, but some styling depends on internal DOM attributes that may change in future Hermes releases.
+**Stable.** Version 1.3.0 has been exercised in Hermes Desktop and is covered by an automated regression suite. It uses Hermes' supported desktop plugin entry point, but some styling depends on internal DOM attributes that may change in future Hermes releases.
 
 ## What it changes
 
@@ -22,6 +22,7 @@ Codex Skin gives Hermes Desktop a Codex-inspired chat layout while preserving He
 - Cleaner styling for Hermes' native **Voice dictation** and **Reading aloud** surfaces
 - Dynamic Voice dictation and Reading aloud lanes above Tasks, Queue and Background
 - Pixel-matched 736 CSS px Codex composer, with an optional native-width Hermes mode
+- Optional unpinned user messages while keeping Hermes' pinned behavior as the default
 - User-message clamp at 4 lines / 110 px, with a **Show more** control for longer messages
 - Styling for Tasks, Background activity, Clarify, Approval and media surfaces
 
@@ -32,6 +33,7 @@ Codex Skin gives Hermes Desktop a Codex-inspired chat layout while preserving He
 | Codex Skin | On / Off | On after installation | **Settings → Plugins** |
 | Theme | Codex Skin / any native Hermes theme | Hermes choice | **Settings → Appearance** |
 | Composer width | Codex / Hermes | Codex | Command palette |
+| Pinned user messages | Hermes / Off | Hermes | Command palette |
 
 Turning **Codex Skin** off restores Hermes' normal appearance.
 
@@ -43,6 +45,13 @@ Open the command palette and run **Codex Skin: Composer width**. The row shows t
 - **Hermes** restores Hermes' native full-width composer and conversation column.
 
 The `+` menu above the composer follows the rendered composer width in both modes.
+
+### Pinned user messages
+
+Open the command palette and run **Codex Skin: Pinned user messages**. The row shows the active mode and the choice persists locally.
+
+- **Hermes** preserves Hermes' native behavior, where the latest user message stays pinned at the top while scrolling.
+- **Off** lets every user message scroll normally with the rest of the conversation.
 
 ## Screenshots
 
@@ -150,7 +159,7 @@ Run **Reload desktop plugins** if Hermes does not unload it automatically.
 
 Desktop plugins execute inside the Hermes renderer and therefore carry the same local authority as the app. Review local plugins before installing them.
 
-This plugin performs no network requests and stores no message text, prompt hashes or content fingerprints. It keeps a bounded local list of profile/session/message IDs for user messages that were manually expanded, capped at 250 entries, plus the **Composer width** preference.
+This plugin performs no network requests and stores no message text, prompt hashes or content fingerprints. It keeps a bounded local list of profile/session/message IDs for user messages that were manually expanded, capped at 250 entries, plus the **Composer width** and **Pinned user messages** preferences.
 
 ## Compatibility
 

--- a/codex-chat-look/plugin.js
+++ b/codex-chat-look/plugin.js
@@ -4,12 +4,13 @@ import { jsx } from 'react/jsx-runtime'
 
 const ID = 'codex-chat-look'
 const STYLE_ID = `${ID}-styles`
-const BUILD_ID = 'v1.2.0'
+const BUILD_ID = 'v1.3.0'
 const STORAGE_PREFIX = `${ID}:turn:`
 const LONG_USER_STATE_SUFFIX = ':long-user-expanded'
 const MAX_PERSISTED_LONG_USER_STATES = 250
 const RUNTIME_HANDOFF_KEY = '__hermesCodexChatLookRuntimeHandoff'
 const COMPOSER_WIDTH_STORAGE_KEY = 'composer-width'
+const PINNED_USER_MESSAGES_STORAGE_KEY = 'pinned-user-messages'
 const PLAYBACK_CLOSE_GRACE_MS = 250
 const PLAYBACK_MOTION_MS = 240
 let pluginStorage = null
@@ -164,6 +165,14 @@ html[data-codex-chat-look='true'] [data-slot='aui_thread-content'] {
    transcript; the visible sent-message surface remains its own child. */
 html[data-codex-chat-look='true'] [data-slot='aui_user-message-root'] {
   background: transparent !important;
+}
+
+/* Hermes pins each user prompt to the top of the thread. Keep that native
+   behavior unless the user explicitly opts out through the plugin setting. */
+html[data-codex-chat-look='true'][data-codex-pinned-user-messages='off'] [data-slot='aui_user-message-root'] {
+  position: static !important;
+  top: auto !important;
+  z-index: auto !important;
 }
 
 /* Keep one live-tail wrapper fully laid out only while the viewport is at the
@@ -1589,6 +1598,27 @@ function setComposerWidthMode(mode) {
   window.requestAnimationFrame(() => decorateComposerChrome())
 }
 
+function readPinnedUserMessagesMode() {
+  try {
+    const mode = pluginStorage?.get(PINNED_USER_MESSAGES_STORAGE_KEY, 'hermes')
+    return mode === 'off' ? 'off' : 'hermes'
+  } catch {
+    return 'hermes'
+  }
+}
+
+function syncPinnedUserMessagesRoot() {
+  const mode = readPinnedUserMessagesMode()
+  document.documentElement.setAttribute('data-codex-pinned-user-messages', mode)
+  return mode
+}
+
+function setPinnedUserMessagesMode(mode) {
+  const normalized = mode === 'off' ? 'off' : 'hermes'
+  pluginStorage?.set(PINNED_USER_MESSAGES_STORAGE_KEY, normalized)
+  syncPinnedUserMessagesRoot()
+}
+
 function installBehaviorRuntime(afterFinalCleanup = null) {
   const pendingHandoff = window[RUNTIME_HANDOFF_KEY]
   if (pendingHandoff?.timer) window.clearTimeout(pendingHandoff.timer)
@@ -2164,10 +2194,12 @@ function CodexChatStyleRuntime() {
     root.dataset.codexChatLook = 'true'
     root.dataset.codexChatLookBuild = BUILD_ID
     syncComposerWidthRoot()
+    syncPinnedUserMessagesRoot()
     const uninstallBehavior = installBehaviorRuntime(() => {
       style?.remove()
       delete root.dataset.codexChatLook
       root.removeAttribute('data-codex-composer-width')
+      root.removeAttribute('data-codex-pinned-user-messages')
       if (root.dataset.codexChatLookBuild === BUILD_ID) delete root.dataset.codexChatLookBuild
       if (root.dataset.codexChatLookRuntime === BUILD_ID) delete root.dataset.codexChatLookRuntime
     })
@@ -2197,6 +2229,19 @@ export default {
         keepOpen: true,
         keywords: ['codex', 'skin', 'composer', 'width', 'narrow', 'full', 'hermes'],
         run: () => setComposerWidthMode(readComposerWidthMode() === 'codex' ? 'hermes' : 'codex')
+      }
+    })
+    ctx.register({
+      id: 'toggle-pinned-user-messages',
+      area: PALETTE_AREA,
+      data: {
+        id: 'codex-chat-look.toggle-pinned-user-messages',
+        label: 'Codex Skin: Pinned user messages',
+        detail: () => (readPinnedUserMessagesMode() === 'hermes' ? 'Hermes' : 'Off'),
+        detailVariant: 'state',
+        keepOpen: true,
+        keywords: ['codex', 'skin', 'pinned', 'sticky', 'user', 'message', 'prompt', 'hermes'],
+        run: () => setPinnedUserMessagesMode(readPinnedUserMessagesMode() === 'hermes' ? 'off' : 'hermes')
       }
     })
     ctx.register({

--- a/test/helpers/load-plugin.mjs
+++ b/test/helpers/load-plugin.mjs
@@ -3,7 +3,7 @@ import vm from 'node:vm'
 
 const pluginUrl = new URL('../../codex-chat-look/plugin.js', import.meta.url)
 
-export async function loadPluginInternals(names = []) {
+export async function loadPluginInternals(names = [], overrides = {}) {
   let source = await readFile(pluginUrl, 'utf8')
   source = source.replace(/^import .*$/gm, '').replace(/export default\s*\{/, 'globalThis.__pluginDefault = {')
   const exposed = names
@@ -27,7 +27,8 @@ export async function loadPluginInternals(names = []) {
     TITLEBAR_AREAS: { center: 'center' },
     PALETTE_AREA: 'palette',
     window: { location: { hash: '#/theme-test' } },
-    console
+    console,
+    ...overrides
   })
   context.globalThis = context
   vm.runInContext(source, context, { filename: pluginUrl.pathname })

--- a/test/pinned-user-messages.test.mjs
+++ b/test/pinned-user-messages.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { loadPluginInternals } from './helpers/load-plugin.mjs'
+
+function rootFixture() {
+  const attributes = new Map()
+  return {
+    attributes,
+    document: {
+      documentElement: {
+        getAttribute: name => attributes.get(name) ?? null,
+        removeAttribute: name => attributes.delete(name),
+        setAttribute: (name, value) => attributes.set(name, String(value))
+      }
+    }
+  }
+}
+
+async function pluginFixture(initialStorage = {}) {
+  const values = new Map(Object.entries(initialStorage))
+  const registrations = []
+  const root = rootFixture()
+  const internals = await loadPluginInternals(
+    [
+      '__pluginDefault',
+      'readPinnedUserMessagesMode',
+      'setPinnedUserMessagesMode',
+      'syncPinnedUserMessagesRoot'
+    ],
+    { document: root.document }
+  )
+
+  internals.__pluginDefault.register({
+    storage: {
+      get: (key, fallback) => values.has(key) ? values.get(key) : fallback,
+      set: (key, value) => values.set(key, value)
+    },
+    register: contribution => registrations.push(contribution)
+  })
+
+  return { internals, registrations, root, values }
+}
+
+test('pinned user messages preserve Hermes behavior by default', async () => {
+  const fixture = await pluginFixture()
+
+  assert.equal(fixture.internals.readPinnedUserMessagesMode(), 'hermes')
+  assert.equal(fixture.internals.syncPinnedUserMessagesRoot(), 'hermes')
+  assert.equal(fixture.root.attributes.get('data-codex-pinned-user-messages'), 'hermes')
+})
+
+test('palette setting toggles Off and persists it across a plugin reload', async () => {
+  const fixture = await pluginFixture()
+  const command = fixture.registrations.find(item => item.id === 'toggle-pinned-user-messages')
+
+  assert.ok(command)
+  assert.equal(command.data.label, 'Codex Skin: Pinned user messages')
+  assert.equal(command.data.detail(), 'Hermes')
+
+  command.data.run()
+  assert.equal(fixture.values.get('pinned-user-messages'), 'off')
+  assert.equal(fixture.root.attributes.get('data-codex-pinned-user-messages'), 'off')
+  assert.equal(command.data.detail(), 'Off')
+
+  const reloaded = await pluginFixture({ 'pinned-user-messages': fixture.values.get('pinned-user-messages') })
+  assert.equal(reloaded.internals.readPinnedUserMessagesMode(), 'off')
+  assert.equal(reloaded.internals.syncPinnedUserMessagesRoot(), 'off')
+
+  reloaded.internals.setPinnedUserMessagesMode('hermes')
+  assert.equal(reloaded.values.get('pinned-user-messages'), 'hermes')
+  assert.equal(reloaded.root.attributes.get('data-codex-pinned-user-messages'), 'hermes')
+})


### PR DESCRIPTION
## Summary

- Add **Codex Skin: Pinned user messages** with persisted `Hermes` and `Off` modes.
- Keep Hermes native pinning as the default.
- Document the setting and add regression coverage for default, toggle and persistence behavior.

## Verification

- [x] `node --check codex-chat-look/plugin.js`
- [x] `node --test test/*.test.mjs` — 64 passed
- [x] Live Hermes Desktop: `Hermes` = sticky, `Off` = static, preference preserved
- [x] Independent exact-fingerprint review: PASS