### PR TITLE
release: Codex Skin v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented here.
 
+## [1.3.1] - 2026-08-29
+
+### Improved
+
+- Reduced the composer task-status contrast by blending the active theme's tertiary color into the chat background, keeping the panel quieter without replacing the selected theme.
+
+### Verification
+
+- 65 automated checks pass.
+- The final contrast was selected in the live Hermes Desktop renderer with the Solarized light theme.
+
 ## [1.3.0] - 2026-08-29
 
 ### Added

--- a/CHECKSUMS.sha256
+++ b/CHECKSUMS.sha256
@@ -1,1 +1,1 @@
-035a10170eb341569048672b3c7d10331d5ac36cd884c16ec251694471342fc3  codex-chat-look/plugin.js
+8f8335a8120bcced9def5a649df0b6949f9d87de0084c56e8c4117f4133e0dc1  codex-chat-look/plugin.js

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Codex Skin gives Hermes Desktop a Codex-inspired chat layout while preserving He
 
 ## Status
 
-**Stable.** Version 1.3.0 has been exercised in Hermes Desktop and is covered by an automated regression suite. It uses Hermes' supported desktop plugin entry point, but some styling depends on internal DOM attributes that may change in future Hermes releases.
+**Stable.** Version 1.3.1 has been exercised in Hermes Desktop and is covered by an automated regression suite. It uses Hermes' supported desktop plugin entry point, but some styling depends on internal DOM attributes that may change in future Hermes releases.
 
 ## What it changes
 

--- a/codex-chat-look/plugin.js
+++ b/codex-chat-look/plugin.js
@@ -4,7 +4,7 @@ import { jsx } from 'react/jsx-runtime'
 
 const ID = 'codex-chat-look'
 const STYLE_ID = `${ID}-styles`
-const BUILD_ID = 'v1.3.0'
+const BUILD_ID = 'v1.3.1'
 const STORAGE_PREFIX = `${ID}:turn:`
 const LONG_USER_STATE_SUFFIX = ':long-user-expanded'
 const MAX_PERSISTED_LONG_USER_STATES = 250
@@ -95,7 +95,11 @@ html[data-codex-chat-look='true'] {
   --codex-color-card: var(--dt-card, var(--ui-editor-surface-background));
   --codex-color-elevated: var(--dt-popover, var(--ui-widget-surface-background));
   --codex-color-bubble: var(--ui-chat-bubble-background);
-  --codex-color-status-panel: var(--ui-bg-tertiary, var(--codex-color-card));
+  --codex-color-status-panel: color-mix(
+    in srgb,
+    var(--ui-bg-tertiary, var(--codex-color-card)) 32.5%,
+    var(--codex-color-chat)
+  );
   --codex-color-text: var(--ui-text-primary);
   --codex-color-text-secondary: var(--ui-text-secondary);
   --codex-color-text-tertiary: var(--ui-text-tertiary);
@@ -136,10 +140,6 @@ html[data-codex-chat-look='true'][data-hermes-theme='codex-chat'][data-hermes-gl
 html[data-codex-chat-look='true'][data-hermes-theme='codex-chat']:not([data-hermes-glass]),
 html[data-codex-chat-look='true'][data-hermes-theme='codex-chat']:not([data-hermes-glass]) body {
   background-color: var(--codex-color-chat) !important;
-}
-
-html[data-codex-chat-look='true'][data-hermes-theme='codex-chat'][data-hermes-mode='light'] {
-  --codex-color-status-panel: color-mix(in srgb, var(--theme-card-seed) 96%, var(--dt-foreground));
 }
 
 html[data-codex-chat-look='true'][data-codex-composer-width='codex'] {

--- a/test/theme-inheritance.test.mjs
+++ b/test/theme-inheritance.test.mjs
@@ -52,6 +52,15 @@ test('theme changes stay live because every plugin color resolves through CSS va
   assert.deepEqual([...themeOverrides], ['codex-chat'])
 })
 
+test('composer task status keeps the active theme with reduced contrast', () => {
+  assert.equal([...CSS.matchAll(/--codex-color-status-panel\s*:/g)].length, 1)
+  assert.match(
+    CSS,
+    /--codex-color-status-panel:\s*color-mix\([\s\S]{0,120}var\(--ui-bg-tertiary, var\(--codex-color-card\)\) 32\.5%,[\s\S]{0,80}var\(--codex-color-chat\)/
+  )
+  assert.doesNotMatch(CSS, /data-hermes-theme=['"]codex-chat['"][^{]*\{[^}]*--codex-color-status-panel/)
+})
+
 test('composer keeps a uniform real border and a downward shadow without rings', () => {
   const start = CSS.indexOf("[data-slot='composer-surface'] {")
   assert.notEqual(start, -1)


### PR DESCRIPTION
## Summary

- Reduce the composer task-status contrast so the panel stays visible without drawing too much attention.
- Preserve the active Hermes theme by blending its tertiary color with the chat background.
- Apply the same rule across native themes, the bundled Codex theme and Glass.

## Verification

- [x] `node --check codex-chat-look/plugin.js`
- [x] `node --test test/*.test.mjs` — 65 passed
- [x] Live Hermes Desktop: final contrast approved with Solarized light
- [x] Independent exact-fingerprint review: PASS
